### PR TITLE
Fix datasource URLs in dev compose file

### DIFF
--- a/backend/docker-compose.dev.yml
+++ b/backend/docker-compose.dev.yml
@@ -58,7 +58,7 @@ services:
     environment:
       - SPRING_PROFILES_ACTIVE=docker
       - EUREKA_CLIENT_SERVICE-URL_DEFAULTZONE=http://eureka-server:8761/eureka/
-      - SPRING_DATASOURCE_URL=jdbc:postgresql://postgres:5432/quiz_platform
+      - SPRING_DATASOURCE_URL=jdbc:postgresql://postgres:5432/quiz_platform?currentSchema=user_schema
       - SPRING_DATASOURCE_USERNAME=quizuser
       - SPRING_DATASOURCE_PASSWORD=quizpass
       - KAFKA_BOOTSTRAP_SERVERS=kafka:29092
@@ -86,7 +86,7 @@ services:
     environment:
       - SPRING_PROFILES_ACTIVE=docker
       - EUREKA_CLIENT_SERVICE-URL_DEFAULTZONE=http://eureka-server:8761/eureka/
-      - SPRING_DATASOURCE_URL=jdbc:postgresql://postgres:5432/quiz_platform
+      - SPRING_DATASOURCE_URL=jdbc:postgresql://postgres:5432/quiz_platform?currentSchema=quiz_schema
       - SPRING_DATASOURCE_USERNAME=quizuser
       - SPRING_DATASOURCE_PASSWORD=quizpass
       - SPRING_ELASTICSEARCH_REST_URIS=http://elasticsearch:9200
@@ -116,7 +116,7 @@ services:
     environment:
       - SPRING_PROFILES_ACTIVE=docker
       - EUREKA_CLIENT_SERVICE-URL_DEFAULTZONE=http://eureka-server:8761/eureka/
-      - SPRING_DATASOURCE_URL=jdbc:postgresql://postgres:5432/quiz_platform
+      - SPRING_DATASOURCE_URL=jdbc:postgresql://postgres:5432/quiz_platform?currentSchema=battle_schema
       - SPRING_DATASOURCE_USERNAME=quizuser
       - SPRING_DATASOURCE_PASSWORD=quizpass
       - SPRING_REDIS_HOST=redis


### PR DESCRIPTION
## Summary
- update datasource URLs in docker-compose.dev.yml so each service uses the schema specified in its `application-docker.yml`

## Testing
- `bash run_tests.sh` *(fails: could not find GradleWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_e_683fa069b0088322b6f3cab419136abe