### PR TITLE
Add Spring Cloud Config dev setup

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -185,6 +185,17 @@ project(':modules:eureka-server') {
     }
 }
 
+project(':modules:config-server') {
+    bootJar {
+        enabled = true
+        mainClass.set('com.quizplatform.configserver.ConfigServerApplication')
+    }
+
+    dependencies {
+        implementation 'org.springframework.cloud:spring-cloud-config-server'
+    }
+}
+
 dependencies {
     implementation project(':modules:common')
     implementation project(':modules:user')
@@ -192,6 +203,7 @@ dependencies {
     implementation project(':modules:battle')
     implementation project(':modules:api-gateway')
     implementation project(':modules:eureka-server')
+    implementation project(':modules:config-server')
     
     implementation 'org.springframework.boot:spring-boot-starter-web'
 //    implementation 'org.springframework.boot:spring-boot-starter-security'

--- a/backend/docker-compose.dev.yml
+++ b/backend/docker-compose.dev.yml
@@ -1,6 +1,25 @@
 version: '3.8'
 
 services:
+  # 설정 서버
+  config-server:
+    build:
+      context: .
+      dockerfile: ./modules/config-server/Dockerfile
+    container_name: quiz-config-server-dev
+    ports:
+      - "8888:8888"
+      - "5888:5888"  # 디버깅 포트
+    environment:
+      - SPRING_PROFILES_ACTIVE=docker
+      - CONFIG_GIT_URI=file:///app/config-repo
+      - JAVA_TOOL_OPTIONS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5888
+    volumes:
+      - ./modules/config-server:/workspace/app
+      - maven-repo:/root/.m2
+    networks:
+      - quiz-network
+    restart: unless-stopped
   # API 게이트웨이 서비스
   api-gateway:
     build:
@@ -20,6 +39,7 @@ services:
       - ./modules/api-gateway:/workspace/app
       - maven-repo:/root/.m2
     depends_on:
+      - config-server
       - eureka-server
       - redis
       - kafka
@@ -42,6 +62,8 @@ services:
     volumes:
       - ./modules/eureka-server:/workspace/app
       - maven-repo:/root/.m2
+    depends_on:
+      - config-server
     networks:
       - quiz-network
     restart: unless-stopped
@@ -68,6 +90,7 @@ services:
       - maven-repo:/root/.m2
     depends_on:
       - postgres
+      - config-server
       - eureka-server
       - kafka
     networks:
@@ -97,6 +120,7 @@ services:
       - maven-repo:/root/.m2
     depends_on:
       - postgres
+      - config-server
       - eureka-server
       - elasticsearch
       - kafka
@@ -129,6 +153,7 @@ services:
     depends_on:
       - postgres
       - redis
+      - config-server
       - eureka-server
       - kafka
     networks:

--- a/backend/modules/config-server/Dockerfile
+++ b/backend/modules/config-server/Dockerfile
@@ -1,0 +1,27 @@
+# 빌드 스테이지
+FROM gradle:7.6-jdk17 AS build
+
+WORKDIR /workspace/app
+
+# 프로젝트 파일 복사
+COPY . .
+
+# Gradle 명령으로 해당 모듈 빌드
+RUN gradle :modules:config-server:clean :modules:config-server:build -x test
+
+# 런타임 이미지
+FROM eclipse-temurin:17-jre-alpine
+WORKDIR /app
+
+# 빌드 단계에서 생성된 JAR 파일 복사
+COPY --from=build /workspace/app/modules/config-server/build/libs/*.jar app.jar
+
+# 환경 변수 설정
+ENV SPRING_PROFILES_ACTIVE=docker
+ENV SERVER_PORT=8888
+
+# 포트 노출
+EXPOSE 8888
+
+# 애플리케이션 실행
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/backend/modules/config-server/build.gradle
+++ b/backend/modules/config-server/build.gradle
@@ -1,0 +1,14 @@
+dependencyManagement {
+    imports {
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:2023.0.0"
+    }
+}
+
+dependencies {
+    implementation 'org.springframework.cloud:spring-cloud-config-server'
+}
+
+bootJar {
+    enabled = true
+    mainClass.set('com.quizplatform.configserver.ConfigServerApplication')
+}

--- a/backend/modules/config-server/src/main/java/com/quizplatform/configserver/ConfigServerApplication.java
+++ b/backend/modules/config-server/src/main/java/com/quizplatform/configserver/ConfigServerApplication.java
@@ -1,0 +1,16 @@
+package com.quizplatform.configserver;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.config.server.EnableConfigServer;
+
+/**
+ * Spring Cloud Config 서버 애플리케이션
+ */
+@SpringBootApplication
+@EnableConfigServer
+public class ConfigServerApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(ConfigServerApplication.class, args);
+    }
+}

--- a/backend/modules/config-server/src/main/resources/application-dev.yml
+++ b/backend/modules/config-server/src/main/resources/application-dev.yml
@@ -1,0 +1,11 @@
+server:
+  port: 8888
+
+spring:
+  application:
+    name: config-server
+  cloud:
+    config:
+      server:
+        git:
+          uri: ${CONFIG_GIT_URI:file:///app/config-repo}

--- a/backend/modules/config-server/src/main/resources/application.yml
+++ b/backend/modules/config-server/src/main/resources/application.yml
@@ -1,0 +1,11 @@
+server:
+  port: 8888
+
+spring:
+  application:
+    name: config-server
+  cloud:
+    config:
+      server:
+        git:
+          uri: ${CONFIG_GIT_URI:file:///app/config-repo}

--- a/backend/modules/config-server/src/main/resources/bootstrap.yml
+++ b/backend/modules/config-server/src/main/resources/bootstrap.yml
@@ -1,0 +1,3 @@
+spring:
+  application:
+    name: config-server


### PR DESCRIPTION
## Summary
- add `application-dev.yml` for config server
- include config-server service in dev Docker Compose
- update dependencies in dev Docker Compose to wait for config-server

## Testing
- `gradle test` *(fails to locate JDK 17 toolchain)*

------
https://chatgpt.com/codex/tasks/task_e_683fa028817883228da637eb3237e4ec