### PR TITLE
Fix config-server datasource autoconfig error

### DIFF
--- a/backend/modules/config-server/src/main/java/com/quizplatform/configserver/ConfigServerApplication.java
+++ b/backend/modules/config-server/src/main/java/com/quizplatform/configserver/ConfigServerApplication.java
@@ -2,12 +2,13 @@ package com.quizplatform.configserver;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.cloud.config.server.EnableConfigServer;
 
 /**
  * Spring Cloud Config 서버 애플리케이션
  */
-@SpringBootApplication
+@SpringBootApplication(exclude = {DataSourceAutoConfiguration.class})
 @EnableConfigServer
 public class ConfigServerApplication {
     public static void main(String[] args) {


### PR DESCRIPTION
## Summary
- prevent datasource auto configuration for config-server module

## Testing
- `./gradlew test` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_e_683fa7d2b3c483228eb3eb55c1efaaf7