### PR TITLE
Add BusinessException usage across modules

### DIFF
--- a/backend/modules/api-gateway/src/main/java/com/quizplatform/apigateway/ApiGatewayApplication.java
+++ b/backend/modules/api-gateway/src/main/java/com/quizplatform/apigateway/ApiGatewayApplication.java
@@ -7,7 +7,7 @@ import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 /**
  * API Gateway 서비스 애플리케이션 진입점
  */
-@SpringBootApplication
+@SpringBootApplication(scanBasePackages = {"com.quizplatform.apigateway", "com.quizplatform.common"})
 @EnableDiscoveryClient
 public class ApiGatewayApplication {
     public static void main(String[] args) {

--- a/backend/modules/battle/src/main/java/com/quizplatform/battle/application/service/BattleServiceImpl.java
+++ b/backend/modules/battle/src/main/java/com/quizplatform/battle/application/service/BattleServiceImpl.java
@@ -12,6 +12,8 @@ import org.springframework.context.event.EventListener;
 import org.springframework.beans.factory.annotation.Value;
 
 import java.time.LocalDateTime;
+import com.quizplatform.common.exception.BusinessException;
+import com.quizplatform.common.exception.ErrorCode;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -128,7 +130,7 @@ public class BattleServiceImpl implements BattleService {
         // 참가자 맵에서 조회
         Map<Long, BattleParticipant> participants = participantsMap.get(roomId);
         if (participants == null || !participants.containsKey(userId)) {
-            throw new NoSuchElementException("참가자를 찾을 수 없습니다");
+            throw new BusinessException(ErrorCode.PARTICIPANT_NOT_FOUND);
         }
         
         // 준비 상태 토글
@@ -346,7 +348,7 @@ public class BattleServiceImpl implements BattleService {
         // 방 정보 가져오기
         BattleJoinResponse room = roomsMap.get(roomId);
         if (room == null) {
-            throw new NoSuchElementException("배틀방을 찾을 수 없습니다");
+            throw new BusinessException(ErrorCode.BATTLE_ROOM_NOT_FOUND);
         }
         
         // 참가자 맵에서 제거

--- a/backend/modules/battle/src/main/java/com/quizplatform/battle/domain/model/BattleRoom.java
+++ b/backend/modules/battle/src/main/java/com/quizplatform/battle/domain/model/BattleRoom.java
@@ -1,5 +1,7 @@
 package com.quizplatform.battle.domain.model;
 
+import com.quizplatform.common.exception.BusinessException;
+import com.quizplatform.common.exception.ErrorCode;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -190,13 +192,13 @@ public class BattleRoom {
      */
     private void validateParticipantAddition(Long userId) {
         if (status != BattleRoomStatus.WAITING) {
-            throw new IllegalStateException("이미 시작된 배틀입니다.");
+            throw new BusinessException(ErrorCode.BATTLE_ALREADY_STARTED);
         }
         if (isParticipantLimitReached()) {
-            throw new IllegalStateException("배틀 방이 가득 찼습니다.");
+            throw new BusinessException(ErrorCode.BATTLE_ROOM_FULL);
         }
         if (hasParticipant(userId)) {
-            throw new IllegalStateException("이미 참가 중인 사용자입니다.");
+            throw new BusinessException(ErrorCode.ALREADY_PARTICIPATING);
         }
     }
 
@@ -216,10 +218,10 @@ public class BattleRoom {
      */
     public void startBattle() {
         if (status != BattleRoomStatus.WAITING) {
-            throw new IllegalStateException("이미 시작된 배틀입니다.");
+            throw new BusinessException(ErrorCode.BATTLE_ALREADY_STARTED);
         }
         if (!isReadyToStart()) {
-            throw new IllegalStateException("아직 준비되지 않았습니다.");
+            throw new BusinessException(ErrorCode.NOT_READY_TO_START);
         }
         this.currentQuestionIndex = -1; // 인덱스 초기화 (첫 번째 문제로 진행할 준비)
         this.status = BattleRoomStatus.IN_PROGRESS;
@@ -240,7 +242,7 @@ public class BattleRoom {
      */
     public void startNextQuestion() {
         if (status != BattleRoomStatus.IN_PROGRESS) {
-            throw new IllegalStateException("진행 중인 배틀이 아닙니다.");
+            throw new BusinessException(ErrorCode.BATTLE_NOT_IN_PROGRESS);
         }
         
         // 다음 문제 인덱스로 진행

--- a/backend/modules/common/src/main/java/com/quizplatform/common/exception/BusinessException.java
+++ b/backend/modules/common/src/main/java/com/quizplatform/common/exception/BusinessException.java
@@ -1,0 +1,18 @@
+package com.quizplatform.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public BusinessException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public BusinessException(ErrorCode errorCode, String message) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+}

--- a/backend/modules/common/src/main/java/com/quizplatform/common/exception/ErrorCode.java
+++ b/backend/modules/common/src/main/java/com/quizplatform/common/exception/ErrorCode.java
@@ -1,0 +1,77 @@
+package com.quizplatform.common.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+    // Common Errors
+    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "C001", "잘못된 입력값입니다."),
+    ENTITY_NOT_FOUND(HttpStatus.NOT_FOUND, "C002", "엔티티를 찾을 수 없습니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C003", "서버 내부 오류가 발생했습니다."),
+
+    // User Related Errors
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "U001", "사용자를 찾을 수 없습니다."),
+    DUPLICATE_USERNAME(HttpStatus.CONFLICT, "U002", "이미 존재하는 사용자명입니다."),
+    INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "U003", "잘못된 비밀번호입니다."),
+
+    // Quiz Related Errors
+    QUIZ_NOT_FOUND(HttpStatus.NOT_FOUND, "Q001", "퀴즈를 찾을 수 없습니다."),
+    QUIZ_ALREADY_COMPLETED(HttpStatus.CONFLICT, "Q002", "이미 완료된 퀴즈입니다."),
+    QUIZ_TIME_EXPIRED(HttpStatus.FORBIDDEN, "Q003", "퀴즈 시간이 만료되었습니다."),
+    INVALID_QUESTION(HttpStatus.NOT_FOUND,"Q004","잘못된 퀴즈입니다"),
+
+    // Review Related Errors
+    REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "R001", "리뷰를 찾을 수 없습니다."),
+    DUPLICATE_REVIEW(HttpStatus.CONFLICT, "R002", "이미 리뷰를 작성했습니다."),
+    INVALID_REVIEW_RATING(HttpStatus.BAD_REQUEST, "R003", "잘못된 별점입니다."),
+    INVALID_REVIEW_CONTENT(HttpStatus.BAD_REQUEST, "R004", "잘못된 리뷰 내용입니다."),
+
+    // Battle Related Errors
+    BATTLE_ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "B001", "배틀룸을 찾을 수 없습니다."),
+    BATTLE_ROOM_FULL(HttpStatus.CONFLICT, "B002", "배틀룸이 가득 찼습니다."),
+    BATTLE_ALREADY_STARTED(HttpStatus.CONFLICT, "B003", "이미 시작된 배틀입니다."),
+    BATTLE_NOT_STARTED(HttpStatus.FORBIDDEN, "B004", "아직 시작되지 않은 배틀입니다."),
+    BATTLE_NOT_IN_PROGRESS(HttpStatus.FORBIDDEN, "B005", "진행 중이 아닌 배틀입니다."),
+    BATTLE_ALREADY_FINISHED(HttpStatus.CONFLICT, "B006", "이미 종료된 배틀입니다."),
+    INVALID_OPERATION(HttpStatus.CONFLICT,"B007","준비 상태 변경 오류"),
+
+    // Level Related Errors
+    INSUFFICIENT_LEVEL(HttpStatus.FORBIDDEN, "L001", "레벨이 부족합니다."),
+    INVALID_EXPERIENCE_POINTS(HttpStatus.BAD_REQUEST, "L002", "잘못된 경험치 값입니다."),
+
+    // 참가자 관련 에러
+    ALREADY_PARTICIPATING(HttpStatus.CONFLICT, "B010", "이미 참가 중인 사용자입니다."),
+    NOT_READY_TO_START(HttpStatus.FORBIDDEN, "B011", "모든 참가자가 준비되지 않았습니다."),
+    PARTICIPANT_NOT_FOUND(HttpStatus.NOT_FOUND, "B012", "참가자를 찾을 수 없습니다."),
+    NO_PARTICIPANTS(HttpStatus.BAD_REQUEST, "B013", "참가자가 없습니다."),
+
+    // 답변 관련 에러
+    INVALID_QUESTION_SEQUENCE(HttpStatus.BAD_REQUEST, "B020", "잘못된 문제 순서입니다."),
+    ANSWER_ALREADY_SUBMITTED(HttpStatus.CONFLICT, "B021", "이미 답변을 제출했습니다."),
+    ANSWER_NOT_FOUND(HttpStatus.NOT_FOUND, "B022", "답변을 찾을 수 없습니다."),
+    INVALID_ANSWER_FORMAT(HttpStatus.BAD_REQUEST, "B023", "잘못된 답변 형식입니다."),
+
+    // 시간 관련 에러
+    INVALID_TIME_LIMIT(HttpStatus.BAD_REQUEST, "B031", "잘못된 시간 제한입니다."),
+
+    // 점수 관련 에러
+    INVALID_BONUS_POINTS(HttpStatus.BAD_REQUEST, "B040", "잘못된 보너스 점수입니다."),
+    SCORE_CALCULATION_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "B041", "점수 계산 중 오류가 발생했습니다."),
+
+    // 배틀 검증 관련 에러
+    INVALID_PARTICIPANT_COUNT(HttpStatus.BAD_REQUEST, "B050", "잘못된 참가자 수입니다."),
+    INVALID_BATTLE_SETTINGS(HttpStatus.BAD_REQUEST, "B051", "잘못된 배틀 설정입니다."),
+    BATTLE_VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "B052", "배틀 검증 오류가 발생했습니다."),
+
+    // 태그 에러
+    TAG_NOT_FOUND(HttpStatus.BAD_REQUEST, "T001","태그가 존재하지 않습니다"),
+
+    PARTICIPANT_INACTIVE(HttpStatus.BAD_REQUEST, "11", "배틀 검증 오류가 발생했습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/backend/modules/common/src/main/java/com/quizplatform/common/exception/ErrorResponse.java
+++ b/backend/modules/common/src/main/java/com/quizplatform/common/exception/ErrorResponse.java
@@ -1,0 +1,42 @@
+package com.quizplatform.common.exception;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class ErrorResponse {
+    private final int status;
+    private final String code;
+    private final String message;
+    private final String detail;
+
+    public static ErrorResponse of(ErrorCode errorCode, String detail) {
+        return ErrorResponse.builder()
+                .status(errorCode.getStatus().value())
+                .code(errorCode.getCode())
+                .message(errorCode.getMessage())
+                .detail(detail)
+                .build();
+    }
+
+    public static ErrorResponse of(ErrorCode errorCode, List<FieldError> fieldErrors) {
+        String detail = fieldErrors.toString();
+        return ErrorResponse.builder()
+                .status(errorCode.getStatus().value())
+                .code(errorCode.getCode())
+                .message(errorCode.getMessage())
+                .detail(detail)
+                .build();
+    }
+
+    @Getter
+    @Builder
+    public static class FieldError {
+        private final String field;
+        private final String value;
+        private final String reason;
+    }
+}

--- a/backend/modules/common/src/main/java/com/quizplatform/common/exception/GlobalExceptionHandler.java
+++ b/backend/modules/common/src/main/java/com/quizplatform/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,50 @@
+package com.quizplatform.common.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestControllerAdvice
+@Slf4j
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(BusinessException.class)
+    protected ResponseEntity<ErrorResponse> handleBusinessException(BusinessException e) {
+        log.error("BusinessException: {}", e.getMessage());
+        ErrorCode errorCode = e.getErrorCode();
+        ErrorResponse response = ErrorResponse.of(errorCode, e.getMessage());
+        return new ResponseEntity<>(response, errorCode.getStatus());
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    protected ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+        log.error("MethodArgumentNotValidException: {}", e.getMessage());
+        List<ErrorResponse.FieldError> fieldErrors = e.getBindingResult()
+                .getFieldErrors()
+                .stream()
+                .map(error -> ErrorResponse.FieldError.builder()
+                        .field(error.getField())
+                        .value(error.getRejectedValue() != null ? error.getRejectedValue().toString() : "")
+                        .reason(error.getDefaultMessage())
+                        .build())
+                .collect(Collectors.toList());
+
+        return new ResponseEntity<>(
+                ErrorResponse.of(ErrorCode.INVALID_INPUT_VALUE, fieldErrors),
+                HttpStatus.BAD_REQUEST
+        );
+    }
+
+    @ExceptionHandler(Exception.class)
+    protected ResponseEntity<ErrorResponse> handleException(Exception e) {
+        log.error("Exception: {}", e.getMessage(), e);
+        ErrorResponse response = ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR, e.getMessage());
+        return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+}

--- a/backend/modules/config-server/src/main/java/com/quizplatform/configserver/ConfigServerApplication.java
+++ b/backend/modules/config-server/src/main/java/com/quizplatform/configserver/ConfigServerApplication.java
@@ -8,7 +8,10 @@ import org.springframework.cloud.config.server.EnableConfigServer;
 /**
  * Spring Cloud Config 서버 애플리케이션
  */
-@SpringBootApplication(exclude = {DataSourceAutoConfiguration.class})
+@SpringBootApplication(
+        scanBasePackages = {"com.quizplatform.configserver", "com.quizplatform.common"},
+        exclude = {DataSourceAutoConfiguration.class}
+)
 @EnableConfigServer
 public class ConfigServerApplication {
     public static void main(String[] args) {

--- a/backend/modules/eureka-server/src/main/java/com/quizplatform/eureka/EurekaServerApplication.java
+++ b/backend/modules/eureka-server/src/main/java/com/quizplatform/eureka/EurekaServerApplication.java
@@ -11,7 +11,7 @@ import org.springframework.cloud.netflix.eureka.server.EnableEurekaServer;
  * @author 채기훈
  * @since JDK 21.0.6 Eclipse Temurin
  */
-@SpringBootApplication
+@SpringBootApplication(scanBasePackages = {"com.quizplatform.eureka", "com.quizplatform.common"})
 @EnableEurekaServer
 public class EurekaServerApplication {
 

--- a/backend/modules/quiz/src/main/java/com/quizplatform/quiz/application/service/QuizApplicationServiceImpl.java
+++ b/backend/modules/quiz/src/main/java/com/quizplatform/quiz/application/service/QuizApplicationServiceImpl.java
@@ -1,5 +1,7 @@
 package com.quizplatform.quiz.application.service;
 
+import com.quizplatform.common.exception.BusinessException;
+import com.quizplatform.common.exception.ErrorCode;
 import com.quizplatform.quiz.application.dto.QuizCreateRequest;
 import com.quizplatform.quiz.application.dto.QuizResponse;
 import com.quizplatform.quiz.application.dto.QuizUpdateRequest;
@@ -14,7 +16,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
 
 /**
@@ -43,7 +44,7 @@ public class QuizApplicationServiceImpl implements QuizApplicationService {
     @Transactional(readOnly = true)
     public QuizResponse getQuizById(Long id) {
         Quiz quiz = quizService.findById(id)
-                .orElseThrow(() -> new NoSuchElementException("퀴즈를 찾을 수 없습니다. ID: " + id));
+                .orElseThrow(() -> new BusinessException(ErrorCode.QUIZ_NOT_FOUND));
         return convertToQuizResponse(quiz);
     }
 

--- a/backend/modules/quiz/src/main/java/com/quizplatform/quiz/domain/service/QuizServiceImpl.java
+++ b/backend/modules/quiz/src/main/java/com/quizplatform/quiz/domain/service/QuizServiceImpl.java
@@ -1,5 +1,7 @@
 package com.quizplatform.quiz.domain.service;
 
+import com.quizplatform.common.exception.BusinessException;
+import com.quizplatform.common.exception.ErrorCode;
 import com.quizplatform.quiz.domain.model.Quiz;
 import com.quizplatform.quiz.domain.model.QuestionAttempt;
 import com.quizplatform.quiz.domain.model.QuizAttempt;
@@ -65,7 +67,7 @@ public class QuizServiceImpl implements QuizService {
     @Transactional
     public QuizAttempt startQuizAttempt(Long quizId, Long userId) {
         Quiz quiz = quizRepository.findById(quizId)
-                .orElseThrow(() -> new IllegalArgumentException("Quiz not found with ID: " + quizId));
+                .orElseThrow(() -> new BusinessException(ErrorCode.QUIZ_NOT_FOUND));
         
         QuizAttempt attempt = QuizAttempt.builder()
                 .quiz(quiz)
@@ -79,7 +81,7 @@ public class QuizServiceImpl implements QuizService {
     @Transactional
     public QuizAttempt submitQuizAttempt(Long attemptId) {
         QuizAttempt attempt = quizAttemptRepository.findById(attemptId)
-                .orElseThrow(() -> new IllegalArgumentException("Quiz attempt not found with ID: " + attemptId));
+                .orElseThrow(() -> new BusinessException(ErrorCode.ENTITY_NOT_FOUND));
         
         // 퀴즈 시도 완료 처리
         boolean passed = attempt.complete();

--- a/backend/modules/user/src/main/java/com/quizplatform/user/adapter/in/web/UserController.java
+++ b/backend/modules/user/src/main/java/com/quizplatform/user/adapter/in/web/UserController.java
@@ -1,5 +1,7 @@
 package com.quizplatform.user.adapter.in.web;
 
+import com.quizplatform.common.exception.BusinessException;
+import com.quizplatform.common.exception.ErrorCode;
 import com.quizplatform.user.domain.model.User;
 import com.quizplatform.user.domain.model.UserRole;
 import com.quizplatform.user.application.service.UserService;
@@ -71,10 +73,9 @@ public class UserController {
     public ResponseEntity<UserResponse> getUserById(
             @Parameter(description = "조회할 사용자의 ID", required = true)
             @PathVariable Long id) {
-        return userService.findById(id)
-                .map(UserResponse::fromEntity)
-                .map(ResponseEntity::ok)
-                .orElse(ResponseEntity.notFound().build());
+        User user = userService.findById(id)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+        return ResponseEntity.ok(UserResponse.fromEntity(user));
     }
 
     /**

--- a/backend/modules/user/src/main/java/com/quizplatform/user/application/service/UserServiceImpl.java
+++ b/backend/modules/user/src/main/java/com/quizplatform/user/application/service/UserServiceImpl.java
@@ -1,5 +1,7 @@
 package com.quizplatform.user.application.service;
 
+import com.quizplatform.common.exception.BusinessException;
+import com.quizplatform.common.exception.ErrorCode;
 import com.quizplatform.user.domain.model.User;
 import com.quizplatform.user.domain.model.UserLevelHistory;
 import com.quizplatform.user.domain.model.UserRole;
@@ -67,7 +69,7 @@ public class UserServiceImpl implements UserService {
         Optional<User> userOpt = userRepository.findById(userId);
         if (userOpt.isEmpty()) {
             log.warn("User not found with ID: {}", userId);
-            return false;
+            throw new BusinessException(ErrorCode.USER_NOT_FOUND);
         }
         
         User user = userOpt.get();
@@ -90,7 +92,7 @@ public class UserServiceImpl implements UserService {
         Optional<User> userOpt = userRepository.findById(userId);
         if (userOpt.isEmpty()) {
             log.warn("User not found with ID: {}", userId);
-            return;
+            throw new BusinessException(ErrorCode.USER_NOT_FOUND);
         }
         
         User user = userOpt.get();
@@ -105,7 +107,7 @@ public class UserServiceImpl implements UserService {
         Optional<User> userOpt = userRepository.findById(userId);
         if (userOpt.isEmpty()) {
             log.warn("User not found with ID: {}", userId);
-            throw new IllegalArgumentException("User not found with ID: " + userId);
+            throw new BusinessException(ErrorCode.USER_NOT_FOUND);
         }
         
         User user = userOpt.get();
@@ -119,7 +121,7 @@ public class UserServiceImpl implements UserService {
         Optional<User> userOpt = userRepository.findById(userId);
         if (userOpt.isEmpty()) {
             log.warn("User not found with ID: {}", userId);
-            throw new IllegalArgumentException("User not found with ID: " + userId);
+            throw new BusinessException(ErrorCode.USER_NOT_FOUND);
         }
         
         User user = userOpt.get();
@@ -133,7 +135,7 @@ public class UserServiceImpl implements UserService {
         Optional<User> userOpt = userRepository.findById(userId);
         if (userOpt.isEmpty()) {
             log.warn("User not found with ID: {}", userId);
-            throw new IllegalArgumentException("User not found with ID: " + userId);
+            throw new BusinessException(ErrorCode.USER_NOT_FOUND);
         }
         
         User user = userOpt.get();


### PR DESCRIPTION
## Summary
- replace legacy exceptions with `BusinessException` and `ErrorCode`
- remove manual error responses in controllers
- propagate global exception handling

## Testing
- `gradle test` *(fails: Could not determine the dependencies of task ':test')*

------
https://chatgpt.com/codex/tasks/task_e_683fe9e6101c8322b3f5906ea0355e57