### PR TITLE
Implement gateway-only JWT auth

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -166,9 +166,6 @@ project(':modules:api-gateway') {
         configurations {
             all*.exclude group: 'org.springframework.boot', module: 'spring-boot-starter-data-redis-reactive'
             all*.exclude group: 'org.springframework.boot', module: 'spring-boot-starter-web'
-            all*.exclude group: 'org.springframework.boot', module: 'spring-boot-starter-security'
-            all*.exclude group: 'org.springframework.security', module: 'spring-security-config'
-            all*.exclude group: 'org.springframework.security', module: 'spring-security-web'
         }
     }
 }

--- a/backend/modules/api-gateway/build.gradle
+++ b/backend/modules/api-gateway/build.gradle
@@ -17,13 +17,16 @@
         // Circuit Breaker - 직접 버전 지정
         implementation 'org.springframework.cloud:spring-cloud-starter-circuitbreaker-resilience4j:3.0.0'
 
+        // Spring Security 및 JWT 의존성 추가
+        implementation 'org.springframework.boot:spring-boot-starter-security'
+        implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+        runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+        runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
         // Rate Limiting과 Redis 의존성 제외
         configurations {
             all*.exclude group: 'org.springframework.boot', module: 'spring-boot-starter-data-redis-reactive'
             all*.exclude group: 'org.springframework.boot', module: 'spring-boot-starter-web'
-            all*.exclude group: 'org.springframework.boot', module: 'spring-boot-starter-security'
-            all*.exclude group: 'org.springframework.security', module: 'spring-security-config'
-            all*.exclude group: 'org.springframework.security', module: 'spring-security-web'
             // 다른 모듈에서 오는 2.2.0 버전 제외
             all*.exclude group: 'org.springdoc', module: 'springdoc-openapi-starter-webmvc-ui'
         }

--- a/backend/modules/api-gateway/src/main/java/com/quizplatform/apigateway/config/security/SecurityConfig.java
+++ b/backend/modules/api-gateway/src/main/java/com/quizplatform/apigateway/config/security/SecurityConfig.java
@@ -1,0 +1,28 @@
+package com.quizplatform.apigateway.config.security;
+
+import com.quizplatform.apigateway.security.JwtAuthenticationFilter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.web.server.ServerHttpSecurity;
+import org.springframework.security.web.server.SecurityWebFilterChain;
+import org.springframework.security.config.web.server.SecurityWebFiltersOrder;
+
+@Configuration
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @Bean
+    public SecurityWebFilterChain securityWebFilterChain(ServerHttpSecurity http) {
+        http
+                .csrf(ServerHttpSecurity.CsrfSpec::disable)
+                .authorizeExchange(ex -> ex
+                        .pathMatchers("/swagger-ui/**", "/v3/api-docs/**", "/webjars/**").permitAll()
+                        .anyExchange().authenticated()
+                )
+                .addFilterAt(jwtAuthenticationFilter, SecurityWebFiltersOrder.AUTHENTICATION);
+        return http.build();
+    }
+}

--- a/backend/modules/api-gateway/src/main/java/com/quizplatform/apigateway/security/JwtAuthenticationFilter.java
+++ b/backend/modules/api-gateway/src/main/java/com/quizplatform/apigateway/security/JwtAuthenticationFilter.java
@@ -1,0 +1,56 @@
+package com.quizplatform.apigateway.security;
+
+import io.jsonwebtoken.Claims;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.Ordered;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.WebFilter;
+import org.springframework.web.server.WebFilterChain;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter implements WebFilter, Ordered {
+
+    private final JwtTokenProvider tokenProvider;
+    private static final List<String> WHITE_LIST = List.of(
+            "/swagger-ui",
+            "/v3/api-docs",
+            "/webjars",
+            "/actuator"
+    );
+
+    @Override
+    public int getOrder() {
+        return -100;
+    }
+
+    @Override
+    public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
+        String path = exchange.getRequest().getPath().value();
+        if (WHITE_LIST.stream().anyMatch(path::startsWith)) {
+            return chain.filter(exchange);
+        }
+
+        String token = exchange.getRequest().getHeaders().getFirst(HttpHeaders.AUTHORIZATION);
+        if (token != null && tokenProvider.validateToken(token)) {
+            Claims claims = tokenProvider.getClaims(token);
+            ServerWebExchange mutated = exchange.mutate()
+                    .request(r -> r.headers(headers -> {
+                        headers.set("X-User-Id", claims.getSubject());
+                        Object roles = claims.get("roles");
+                        if (roles != null) {
+                            headers.set("X-User-Roles", roles.toString());
+                        }
+                    })).build();
+            return chain.filter(mutated);
+        }
+        exchange.getResponse().setStatusCode(HttpStatus.UNAUTHORIZED);
+        return exchange.getResponse().setComplete();
+    }
+}

--- a/backend/modules/api-gateway/src/main/java/com/quizplatform/apigateway/security/JwtTokenProvider.java
+++ b/backend/modules/api-gateway/src/main/java/com/quizplatform/apigateway/security/JwtTokenProvider.java
@@ -1,0 +1,47 @@
+package com.quizplatform.apigateway.security;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import jakarta.annotation.PostConstruct;
+import java.security.Key;
+
+@Component
+public class JwtTokenProvider {
+
+    @Value("${jwt.secret}")
+    private String secret;
+
+    private Key key;
+
+    @PostConstruct
+    public void init() {
+        this.key = Keys.hmacShaKeyFor(secret.getBytes());
+    }
+
+    public boolean validateToken(String token) {
+        if (!StringUtils.hasText(token)) {
+            return false;
+        }
+        if (token.startsWith("Bearer ")) {
+            token = token.substring(7);
+        }
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    public Claims getClaims(String token) {
+        if (token.startsWith("Bearer ")) {
+            token = token.substring(7);
+        }
+        return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody();
+    }
+}

--- a/backend/modules/api-gateway/src/main/resources/application.yml
+++ b/backend/modules/api-gateway/src/main/resources/application.yml
@@ -13,7 +13,6 @@ spring:
   autoconfigure:
     exclude: 
       - org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
-      - org.springframework.boot.autoconfigure.security.reactive.ReactiveSecurityAutoConfiguration
   
   # OAuth2 설정 제거
   
@@ -159,7 +158,9 @@ spring:
   kafka:
     bootstrap-servers: localhost:9092
     
-# JWT 설정 제거
+# JWT 설정
+jwt:
+  secret: changeme-please-change-this-key
     
 # Eureka 클라이언트 설정
 eureka:


### PR DESCRIPTION
## Summary
- add spring security & jjwt to API Gateway
- implement gateway JWT token parsing filter
- secure routes via new SecurityConfig
- add jwt secret placeholder in gateway's `application.yml`
- update build config to allow security dependencies

## Testing
- `gradle :modules:api-gateway:build -x test`


------
https://chatgpt.com/codex/tasks/task_e_683ff8ffdf6c832299a3e323e6ef0525