### PR TITLE
Implement gateway-only JWT auth

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -166,9 +166,6 @@ project(':modules:api-gateway') {
         configurations {
             all*.exclude group: 'org.springframework.boot', module: 'spring-boot-starter-data-redis-reactive'
             all*.exclude group: 'org.springframework.boot', module: 'spring-boot-starter-web'
-            all*.exclude group: 'org.springframework.boot', module: 'spring-boot-starter-security'
-            all*.exclude group: 'org.springframework.security', module: 'spring-security-config'
-            all*.exclude group: 'org.springframework.security', module: 'spring-security-web'
         }
     }
 }

--- a/backend/modules/api-gateway/build.gradle
+++ b/backend/modules/api-gateway/build.gradle
@@ -17,13 +17,16 @@
         // Circuit Breaker - 직접 버전 지정
         implementation 'org.springframework.cloud:spring-cloud-starter-circuitbreaker-resilience4j:3.0.0'
 
+        // Spring Security 및 JWT 의존성 추가
+        implementation 'org.springframework.boot:spring-boot-starter-security'
+        implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+        runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+        runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
         // Rate Limiting과 Redis 의존성 제외
         configurations {
             all*.exclude group: 'org.springframework.boot', module: 'spring-boot-starter-data-redis-reactive'
             all*.exclude group: 'org.springframework.boot', module: 'spring-boot-starter-web'
-            all*.exclude group: 'org.springframework.boot', module: 'spring-boot-starter-security'
-            all*.exclude group: 'org.springframework.security', module: 'spring-security-config'
-            all*.exclude group: 'org.springframework.security', module: 'spring-security-web'
             // 다른 모듈에서 오는 2.2.0 버전 제외
             all*.exclude group: 'org.springdoc', module: 'springdoc-openapi-starter-webmvc-ui'
         }

--- a/backend/modules/api-gateway/src/main/java/com/quizplatform/apigateway/config/security/SecurityConfig.java
+++ b/backend/modules/api-gateway/src/main/java/com/quizplatform/apigateway/config/security/SecurityConfig.java
@@ -1,0 +1,28 @@
+package com.quizplatform.apigateway.config.security;
+
+import com.quizplatform.apigateway.security.JwtAuthenticationFilter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.web.server.ServerHttpSecurity;
+import org.springframework.security.web.server.SecurityWebFilterChain;
+import org.springframework.security.config.web.server.SecurityWebFiltersOrder;
+
+@Configuration
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @Bean
+    public SecurityWebFilterChain securityWebFilterChain(ServerHttpSecurity http) {
+        http
+                .csrf(ServerHttpSecurity.CsrfSpec::disable)
+                .authorizeExchange(ex -> ex
+                        .pathMatchers("/swagger-ui/**", "/v3/api-docs/**", "/webjars/**").permitAll()
+                        .anyExchange().authenticated()
+                )
+                .addFilterAt(jwtAuthenticationFilter, SecurityWebFiltersOrder.AUTHENTICATION);
+        return http.build();
+    }
+}

--- a/backend/modules/api-gateway/src/main/java/com/quizplatform/apigateway/security/JwtAuthenticationFilter.java
+++ b/backend/modules/api-gateway/src/main/java/com/quizplatform/apigateway/security/JwtAuthenticationFilter.java
@@ -1,0 +1,56 @@
+package com.quizplatform.apigateway.security;
+
+import io.jsonwebtoken.Claims;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.Ordered;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.WebFilter;
+import org.springframework.web.server.WebFilterChain;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter implements WebFilter, Ordered {
+
+    private final JwtTokenProvider tokenProvider;
+    private static final List<String> WHITE_LIST = List.of(
+            "/swagger-ui",
+            "/v3/api-docs",
+            "/webjars",
+            "/actuator"
+    );
+
+    @Override
+    public int getOrder() {
+        return -100;
+    }
+
+    @Override
+    public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
+        String path = exchange.getRequest().getPath().value();
+        if (WHITE_LIST.stream().anyMatch(path::startsWith)) {
+            return chain.filter(exchange);
+        }
+
+        String token = exchange.getRequest().getHeaders().getFirst(HttpHeaders.AUTHORIZATION);
+        if (token != null && tokenProvider.validateToken(token)) {
+            Claims claims = tokenProvider.getClaims(token);
+            ServerWebExchange mutated = exchange.mutate()
+                    .request(r -> r.headers(headers -> {
+                        headers.set("X-User-Id", claims.getSubject());
+                        Object roles = claims.get("roles");
+                        if (roles != null) {
+                            headers.set("X-User-Roles", roles.toString());
+                        }
+                    })).build();
+            return chain.filter(mutated);
+        }
+        exchange.getResponse().setStatusCode(HttpStatus.UNAUTHORIZED);
+        return exchange.getResponse().setComplete();
+    }
+}

--- a/backend/modules/api-gateway/src/main/java/com/quizplatform/apigateway/security/JwtTokenProvider.java
+++ b/backend/modules/api-gateway/src/main/java/com/quizplatform/apigateway/security/JwtTokenProvider.java
@@ -1,0 +1,47 @@
+package com.quizplatform.apigateway.security;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import jakarta.annotation.PostConstruct;
+import java.security.Key;
+
+@Component
+public class JwtTokenProvider {
+
+    @Value("${jwt.secret}")
+    private String secret;
+
+    private Key key;
+
+    @PostConstruct
+    public void init() {
+        this.key = Keys.hmacShaKeyFor(secret.getBytes());
+    }
+
+    public boolean validateToken(String token) {
+        if (!StringUtils.hasText(token)) {
+            return false;
+        }
+        if (token.startsWith("Bearer ")) {
+            token = token.substring(7);
+        }
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    public Claims getClaims(String token) {
+        if (token.startsWith("Bearer ")) {
+            token = token.substring(7);
+        }
+        return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody();
+    }
+}

--- a/backend/modules/api-gateway/src/main/resources/application.yml
+++ b/backend/modules/api-gateway/src/main/resources/application.yml
@@ -13,7 +13,6 @@ spring:
   autoconfigure:
     exclude: 
       - org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
-      - org.springframework.boot.autoconfigure.security.reactive.ReactiveSecurityAutoConfiguration
   
   # OAuth2 설정 제거
   
@@ -159,7 +158,9 @@ spring:
   kafka:
     bootstrap-servers: localhost:9092
     
-# JWT 설정 제거
+# JWT 설정
+jwt:
+  secret: changeme-please-change-this-key
     
 # Eureka 클라이언트 설정
 eureka:

--- a/backend/modules/battle/src/main/java/com/quizplatform/battle/infrastructure/config/WebConfig.java
+++ b/backend/modules/battle/src/main/java/com/quizplatform/battle/infrastructure/config/WebConfig.java
@@ -1,15 +1,23 @@
 package com.quizplatform.battle.infrastructure.config;
 
+import com.quizplatform.common.auth.CurrentUserArgumentResolver;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
 
 /**
  * Battle 서비스의 웹 설정
  * 보안 기능 제거 후 기본 CORS 설정만 제공
  */
 @Configuration
+@RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
+
+    private final CurrentUserArgumentResolver currentUserArgumentResolver;
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {
@@ -18,5 +26,10 @@ public class WebConfig implements WebMvcConfigurer {
                 .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
                 .allowedHeaders("*")
                 .maxAge(3600);
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(currentUserArgumentResolver);
     }
 }

--- a/backend/modules/common/src/main/java/com/quizplatform/common/auth/CurrentUser.java
+++ b/backend/modules/common/src/main/java/com/quizplatform/common/auth/CurrentUser.java
@@ -1,0 +1,9 @@
+package com.quizplatform.common.auth;
+
+import java.lang.annotation.*;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface CurrentUser {
+}

--- a/backend/modules/common/src/main/java/com/quizplatform/common/auth/CurrentUserArgumentResolver.java
+++ b/backend/modules/common/src/main/java/com/quizplatform/common/auth/CurrentUserArgumentResolver.java
@@ -1,0 +1,41 @@
+package com.quizplatform.common.auth;
+
+import com.quizplatform.common.exception.BusinessException;
+import com.quizplatform.common.exception.ErrorCode;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+@Component
+public class CurrentUserArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(CurrentUser.class)
+                && parameter.getParameterType().equals(CurrentUserInfo.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter,
+                                  ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest,
+                                  org.springframework.web.bind.support.WebDataBinderFactory binderFactory) {
+        String userIdHeader = webRequest.getHeader("X-User-Id");
+        if (!StringUtils.hasText(userIdHeader)) {
+            throw new BusinessException(ErrorCode.UNAUTHORIZED, "인증 정보가 없습니다.");
+        }
+        String rolesHeader = webRequest.getHeader("X-User-Roles");
+        List<String> roles = StringUtils.hasText(rolesHeader)
+                ? Arrays.asList(rolesHeader.split(","))
+                : Collections.emptyList();
+        Long id = Long.valueOf(userIdHeader);
+        return new CurrentUserInfo(id, roles);
+    }
+}

--- a/backend/modules/common/src/main/java/com/quizplatform/common/auth/CurrentUserInfo.java
+++ b/backend/modules/common/src/main/java/com/quizplatform/common/auth/CurrentUserInfo.java
@@ -1,0 +1,6 @@
+package com.quizplatform.common.auth;
+
+import java.util.List;
+
+public record CurrentUserInfo(Long id, List<String> roles) {
+}

--- a/backend/modules/common/src/main/java/com/quizplatform/common/exception/ErrorCode.java
+++ b/backend/modules/common/src/main/java/com/quizplatform/common/exception/ErrorCode.java
@@ -11,6 +11,7 @@ public enum ErrorCode {
     INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "C001", "잘못된 입력값입니다."),
     ENTITY_NOT_FOUND(HttpStatus.NOT_FOUND, "C002", "엔티티를 찾을 수 없습니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C003", "서버 내부 오류가 발생했습니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "C004", "인증 정보가 없습니다."),
 
     // User Related Errors
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "U001", "사용자를 찾을 수 없습니다."),

--- a/backend/modules/quiz/src/main/java/com/quizplatform/quiz/infrastructure/config/WebConfig.java
+++ b/backend/modules/quiz/src/main/java/com/quizplatform/quiz/infrastructure/config/WebConfig.java
@@ -1,15 +1,23 @@
 package com.quizplatform.quiz.infrastructure.config;
 
+import com.quizplatform.common.auth.CurrentUserArgumentResolver;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
 
 /**
  * Quiz 서비스의 웹 설정
  * 보안 기능 제거 후 기본 CORS 설정만 제공
  */
 @Configuration
+@RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
+
+    private final CurrentUserArgumentResolver currentUserArgumentResolver;
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {
@@ -18,5 +26,10 @@ public class WebConfig implements WebMvcConfigurer {
                 .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
                 .allowedHeaders("*")
                 .maxAge(3600);
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(currentUserArgumentResolver);
     }
 }

--- a/backend/modules/user/src/main/java/com/quizplatform/user/infrastructure/config/WebConfig.java
+++ b/backend/modules/user/src/main/java/com/quizplatform/user/infrastructure/config/WebConfig.java
@@ -1,15 +1,23 @@
 package com.quizplatform.user.infrastructure.config;
 
+import com.quizplatform.common.auth.CurrentUserArgumentResolver;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
 
 /**
  * User 서비스의 웹 설정
  * 보안 기능 제거 후 기본 CORS 설정만 제공
  */
 @Configuration
+@RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
+
+    private final CurrentUserArgumentResolver currentUserArgumentResolver;
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {
@@ -18,5 +26,10 @@ public class WebConfig implements WebMvcConfigurer {
                 .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
                 .allowedHeaders("*")
                 .maxAge(3600);
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(currentUserArgumentResolver);
     }
 }


### PR DESCRIPTION
## Summary
- add spring security & jjwt to API Gateway
- implement gateway JWT token parsing filter
- secure routes via new SecurityConfig
- add jwt secret placeholder in gateway's `application.yml`
- update build config to allow security dependencies
- add custom `@CurrentUser` argument resolver to convert header info
- register resolver in each service's WebConfig
- define `UNAUTHORIZED` error code for missing header

## Testing
- `gradle :modules:api-gateway:build -x test`


------
https://chatgpt.com/codex/tasks/task_e_683ff8ffdf6c832299a3e323e6ef0525